### PR TITLE
Add optional FEDRAMP version of New Relic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem "colorize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorize (0.8.1)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  colorize
+
+BUNDLED WITH
+   2.2.32

--- a/template.rb
+++ b/template.rb
@@ -146,9 +146,10 @@ if @newrelic
       To get started sending metrics via New Relic APM:
       1. Replace `<APPNAME>` with what is registered for your application in New Relic
       2. Add your New Relic license key to the Rails credentials with key `new_relic_key`.
+      3. Comment out the `agent_enabled: false` line
 
       To enable browser monitoring:
-      3. Embed the Javascript snippet provided  by New Relic into `application.html.erb`. 
+      4. Embed the Javascript snippet provided  by New Relic into `application.html.erb`. 
       It is recommended to vary this based on environment  (i.e. include one snippet 
       for staging and another for production).
 

--- a/template.rb
+++ b/template.rb
@@ -1,3 +1,5 @@
+require 'colorize'
+
 ## Supporting methods
 # tell our template to grab all files from the templates directory
 def source_paths
@@ -28,9 +30,15 @@ unless Gem::Dependency.new("rails", "~> 7.0.0").match?("rails", Rails.gem_versio
   exit(1)
 end
 
+def announce_section(section_name, instructions)
+  $stdout.puts "\n============= #{section_name} ============= ".yellow
+  $stdout.puts instructions
+end
+
 @cloudgov_deploy = yes?("Create cloud.gov deployment files? (y/n)")
 @github_actions = yes?("Create Github Actions? (y/n)")
 @adrs = yes?("Create initial Architecture Decision Records? (y/n)")
+@newrelic = yes?("Create FEDRAMP New Relic config files? (y/n)")
 @node_version = ask("What version of NodeJS are you using? (Blank to skip creating .nvmrc)")
 
 if @node_version.present?
@@ -91,6 +99,23 @@ style_policy = if hotwire?
 else
   "policy.style_src :self"
 end
+
+script_policy = if @newrelic
+  <<~EOM
+    policy.script_src :self, "https://js-agent.newrelic.com", "https://*.nr-data.net"
+  EOM
+else
+  "policy.script_src :self"
+end
+
+connect_policy = if @newrelic
+  <<~EOM
+    policy.connect_src :self, "https://*.nr-data.net"
+  EOM
+else
+  "policy.connect_src :self"
+end
+
 gsub_file csp_initializer, /^#   config.*\|policy\|$.+^#   end$/m, <<EOM
   config.content_security_policy do |policy|
     policy.default_src :self
@@ -99,7 +124,8 @@ gsub_file csp_initializer, /^#   config.*\|policy\|$.+^#   end$/m, <<EOM
     policy.frame_ancestors :none
     policy.img_src :self, :data
     policy.object_src :none
-    policy.script_src :self
+    #{script_policy}
+    #{connect_policy}
     #{style_policy}
   end
 EOM
@@ -108,6 +134,27 @@ uncomment_lines csp_initializer, "Rails.application"
 uncomment_lines csp_initializer, /end$/
 uncomment_lines csp_initializer, "content_security_policy_nonce"
 
+if @newrelic
+  gem "newrelic_rpm", "~> 8.3"
+
+  after_bundle do
+    copy_file "config/newrelic.yml"
+
+    announce_section("New Relic", <<~EOM)
+      A New Relic config file has been written to `config/newrelic.yml`
+
+      To get started sending metrics via New Relic APM:
+      1. Replace `<APPNAME>` with what is registered for your application in New Relic
+      2. Add your New Relic license key to the Rails credentials with key `new_relic_key`.
+
+      To enable browser monitoring:
+      3. Embed the Javascript snippet provided  by New Relic into `application.html.erb`. 
+      It is recommended to vary this based on environment  (i.e. include one snippet 
+      for staging and another for production).
+
+    EOM
+  end
+end
 
 gem_group :development, :test do
   gem "rspec-rails", "~> 5.0"
@@ -201,7 +248,6 @@ after_bundle do
 end
 copy_file "app/views/application/_usa_banner.html.erb"
 
-
 after_bundle do
   rails_command "generate rspec:install"
   gsub_file "spec/spec_helper.rb", /^=(begin|end)$/, ""
@@ -222,7 +268,6 @@ after_bundle do
     rails_command "db:migrate"
   end
 end
-
 
 if @cloudgov_deploy
   template "manifest.yml"

--- a/templates/README.md.tt
+++ b/templates/README.md.tt
@@ -121,6 +121,22 @@ Configuration that changes from staging to production, but is public, should be 
 <% else %>
 TBD
 <% end %>
+
+<% if @newrelic %>
+## Monitoring with New Relic
+
+The [New Relic Ruby agent](https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby) has been installed for monitoring this application.
+
+The config lives at `config/newrelic.yml`, and points to a [FEDRAMP version of the New Relic service as its host](https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/). To access the metrics dashboard, you will need to be connected to VPN.
+
+### Getting started
+
+To get started sending metrics via New Relic APM:
+1. Replace `<APPNAME>` in `config/newrelic.yml` with what is registered for your application in New Relic
+1. Add your New Relic license key to the Rails credentials with key `new_relic_key`.
+1. Add the [Javascript snippet provided by New Relic](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent) into `application.html.erb`. It is recommended to vary this based on environment (i.e. include one snippet for staging and another for production).
+<% end %>
+
 <% if @adrs %>
 
 ## Documentation

--- a/templates/README.md.tt
+++ b/templates/README.md.tt
@@ -134,6 +134,7 @@ The config lives at `config/newrelic.yml`, and points to a [FEDRAMP version of t
 To get started sending metrics via New Relic APM:
 1. Replace `<APPNAME>` in `config/newrelic.yml` with what is registered for your application in New Relic
 1. Add your New Relic license key to the Rails credentials with key `new_relic_key`.
+1. Comment out the `agent_enabled: false` line in `config/newrelic.yml`
 1. Add the [Javascript snippet provided by New Relic](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent) into `application.html.erb`. It is recommended to vary this based on environment (i.e. include one snippet for staging and another for production).
 <% end %>
 

--- a/templates/config/newrelic.yml
+++ b/templates/config/newrelic.yml
@@ -28,8 +28,12 @@ common: &default_settings
     # include js code via partial to comply with CSP settings
     auto_instrument: false
 
-  # To disable the agent regardless of other settings, uncomment the following:
-  # agent_enabled: false
+  # This line disables agent regardless of other settings.
+  # To enable the New Relic agent:
+  # 1) Replace <APPNAME> in this file with the application name you want to show in New Relic
+  # 2) add the New Relic license keys to the appropriate encrypted credentials file(s)
+  # 3) Comment out the line below
+  agent_enabled: false
 
   # Logging level for log/newrelic_agent.log
   log_level: info

--- a/templates/config/newrelic.yml
+++ b/templates/config/newrelic.yml
@@ -1,0 +1,61 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated January 12, 2022
+#
+# This configuration file is custom generated for NewRelic Administration
+#
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: <%= Rails.application.credentials.new_relic_key %>
+  # FEDRAMP-specific New Relic host
+  # https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/
+  host: 'gov-collector.newrelic.com'
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: <APPNAME>
+
+  monitor_mode: true
+
+  distributed_tracing:
+    enabled: true
+
+  browser_monitoring:
+    # include js code via partial to comply with CSP settings
+    auto_instrument: false
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: <APPNAME> (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+ci:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: <APPNAME> (Staging)
+
+production:
+  <<: *default_settings
+  app_name: <APPNAME> (Production)


### PR DESCRIPTION
TBH this one feels a little weird to add, since it seems very specific to FEDRAMP-ed New Relic, and also requires additional configuration after template is generated.

I decided not to include prompting for the New Relic license key and app name in the template generation because it didn't seem like a thing people would normally have on-hand when doing a rails new.

Closes #11 