### PR TITLE
Add translations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ ActionCable is included to enable the [Turbo Streams](https://turbo.hotwired.dev
 1. Optionally create `manifest.yml` and variable files for cloud.gov deployment
 1. Optionally create Github Actions workflows
 1. Optionally create CircleCI workflows
-1. Optionally configure DAP (Digital Analytics Program)
 1. Optionally create [Architecture Decision Records](https://adr.github.io/) for above setup
+1. Optionally create a New Relic config with FEDRAMP-specific host
+1. Optionally configure DAP (Digital Analytics Program)
+1. Optionally add base translation files and routes for Spanish and Simplified Chinese (es.yml and zh.yml)
 1. Commit the resulting project with git (unless `--skip-git` is passed)

--- a/template.rb
+++ b/template.rb
@@ -42,8 +42,8 @@ end
 @newrelic = yes?("Create FEDRAMP New Relic config files? (y/n)")
 @dap = yes?("If this will be a public site, should we include Digital Analytics Program code? (y/n)")
 @supported_languages = [:en]
-@supported_languages.push(:es) if yes?("Add es.yml and Spanish routes?")
-@supported_languages.push(:zh) if yes?("Add zh.yml and Simplified Chinese routes?")
+@supported_languages.push(:es) if yes?("Add Spanish to supported locales, with starter es.yml?")
+@supported_languages.push(:zh) if yes?("Add Simplified Chinese to supported locales, with starter zh.yml?")
 @node_version = ask("What version of NodeJS are you using? (Blank to skip creating .nvmrc)")
 
 # copied from Rails' .ruby-version template implementation
@@ -174,6 +174,7 @@ gem_group :development, :test do
   gem "brakeman", "~> 5.2"
   gem "bundler-audit", "~> 0.9"
   gem "standard", "~> 1.5"
+  gem "i18n-tasks", "~> 0.9"
 end
 
 copy_file "lib/tasks/scanning.rake"
@@ -200,8 +201,11 @@ end
 application "config.i18n.available_locales = #{@supported_languages}"
 application "config.i18n.fallbacks = [:en]"
 after_bundle do
+  # Recommended by i18n-tasks
+  run "cp $(i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/"
+
   if @supported_languages.count > 1
-    announce_section("i18n Translations", <<~EOM)
+    announce_section("i18n Translations", <<~'EOM')
       To add routes for available languages, add the following to `config/routes.rb`:
 
       ```

--- a/template.rb
+++ b/template.rb
@@ -35,6 +35,7 @@ def announce_section(section_name, instructions)
   $stdout.puts instructions
 end
 
+
 @cloudgov_deploy = yes?("Create cloud.gov deployment files? (y/n)")
 @github_actions = yes?("Create Github Actions? (y/n)")
 @circleci_pipeline = yes?("Create CircleCI config? (y/n)")

--- a/template.rb
+++ b/template.rb
@@ -18,6 +18,19 @@ def hotwire?
   !options[:skip_hotwire]
 end
 
+@announcements = {}
+def register_announcement(section_name, instructions)
+  @announcements[section_name.to_sym] = instructions
+end
+
+def print_announcements
+  $stdout.puts "\n============= Post-install announcements ============= ".red
+  @announcements.each do |section_name, instructions|
+    $stdout.puts "\n============= #{section_name} ============= ".yellow
+    $stdout.puts instructions
+  end
+end
+
 unless Gem::Dependency.new("rails", "~> 7.0.0").match?("rails", Rails.gem_version)
   $stderr.puts "This template requires Rails 7.0.x"
   if Gem::Dependency.new("rails", "~> 6.1.0").match?("rails", Rails.gem_version)
@@ -28,11 +41,6 @@ unless Gem::Dependency.new("rails", "~> 7.0.0").match?("rails", Rails.gem_versio
     $stderr.puts "We didn't recognize the version of Rails you are using: #{Rails.version}"
   end
   exit(1)
-end
-
-def announce_section(section_name, instructions)
-  $stdout.puts "\n============= #{section_name} ============= ".yellow
-  $stdout.puts instructions
 end
 
 @cloudgov_deploy = yes?("Create cloud.gov deployment files? (y/n)")
@@ -48,7 +56,6 @@ end
 
 # copied from Rails' .ruby-version template implementation
 @ruby_version = ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}"
-
 
 if @node_version.present?
   # setup nvmrc
@@ -151,7 +158,7 @@ if @newrelic
   after_bundle do
     copy_file "config/newrelic.yml"
 
-    announce_section("New Relic", <<~EOM)
+    register_announcement("New Relic", <<~EOM)
       A New Relic config file has been written to `config/newrelic.yml`
 
       To get started sending metrics via New Relic APM:
@@ -205,7 +212,7 @@ after_bundle do
   run "cp $(i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/"
 
   if @supported_languages.count > 1
-    announce_section("i18n Translations", <<~'EOM')
+    register_announcement("i18n Translations", <<~'EOM')
       To add routes for available languages, add the following to `config/routes.rb`:
 
       ```
@@ -354,4 +361,7 @@ after_bundle do
     git add: '.'
     git commit: "-a -m 'Initial commit'"
   end
+
+  # Post-install announcement
+  print_announcements
 end

--- a/template.rb
+++ b/template.rb
@@ -191,6 +191,8 @@ unless skip_git?
   EOM
 end
 
+# Setup translations
+directory "config/locale"
 
 # setup USWDS
 copy_file "browserslistrc", ".browserslistrc" if webpack?

--- a/templates/README.md.tt
+++ b/templates/README.md.tt
@@ -54,9 +54,9 @@ See the [CSP compliant script tag helpers](./doc/adr/0004-rails-csp-compliant-sc
 more information on setting these up successfully.
 <% end %>
 
-### Managing translation files
+### Managing locale files
 
-We use the gem `i18n-tasks` to manage translation files. Here are a few common tasks:
+We use the gem `i18n-tasks` to manage locale files. Here are a few common tasks:
 
 Add missing keys across locales:
 ```
@@ -75,7 +75,7 @@ $ i18n-tasks unused # shows unused keys
 $ i18n-tasks remove-unused # removes unused keys across locale files
 ```
 
-For more information on usage and helpful rake tasks to manage translation files, see [the documentation](https://github.com/glebm/i18n-tasks#usage).
+For more information on usage and helpful rake tasks to manage locale files, see [the documentation](https://github.com/glebm/i18n-tasks#usage).
 
 ### Testing
 

--- a/templates/README.md.tt
+++ b/templates/README.md.tt
@@ -54,6 +54,29 @@ See the [CSP compliant script tag helpers](./doc/adr/0004-rails-csp-compliant-sc
 more information on setting these up successfully.
 <% end %>
 
+### Managing translation files
+
+We use the gem `i18n-tasks` to manage translation files. Here are a few common tasks:
+
+Add missing keys across locales:
+```
+$ i18n-tasks missing # shows missing keys
+$ i18n-tasks add-missing # adds missing keys across locale files
+```
+
+Key sorting:
+```
+$ i18n-tasks normalize
+```
+
+Removing unused keys:
+```
+$ i18n-tasks unused # shows unused keys
+$ i18n-tasks remove-unused # removes unused keys across locale files
+```
+
+For more information on usage and helpful rake tasks to manage translation files, see [the documentation](https://github.com/glebm/i18n-tasks#usage).
+
 ### Testing
 
 #### Running tests

--- a/templates/app/views/application/_usa_banner.html.erb
+++ b/templates/app/views/application/_usa_banner.html.erb
@@ -1,17 +1,18 @@
-<a class="usa-skipnav" href="#main-content">Skip to main content</a>
-<section class="usa-banner" aria-label="Official government website">
+<a class="usa-skipnav" href="#main-content"><%= t('shared.skip_link') %></a>
+
+<section class="usa-banner site-banner" aria-label="<%= t('shared.banner.official_site') %>">
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <%= image_tag "uswds/dist/img/us_flag_small.png", alt: "U.S. flag", class: "usa-banner__header-flag" %>
+          <%= image_tag "uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">
-            An official website of the United States government
+            <%= t('shared.banner.official_site') %>
           </p>
           <p class="usa-banner__header-action" aria-hidden="true">
-            Here’s how you know
+            <%= t('shared.banner.how') %>
           </p>
         </div>
         <button
@@ -19,7 +20,7 @@
           aria-expanded="false"
           aria-controls="gov-banner"
         >
-          <span class="usa-banner__button-text">Here’s how you know</span>
+          <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
         </button>
       </div>
     </header>
@@ -31,43 +32,16 @@
         <div class="usa-banner__guidance tablet:grid-col-6">
           <%= image_tag "uswds/dist/img/icon-dot-gov.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
           <div class="usa-media-block__body">
-            <p>
-              <strong> Official websites use .gov </strong>
-              <br />
-              A <strong>.gov</strong> website belongs to an official government
-              organization in the United States.
-            </p>
+            <strong><%= t('shared.banner.gov_heading') %></strong>
+            <br> <%= t('shared.banner.gov_description_html') %>
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <%= image_tag "uswds/dist/img/icon-https.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
           <div class="usa-media-block__body">
             <p>
-              <strong> Secure .gov websites use HTTPS </strong>
-              <br />
-              A <strong>lock</strong> (
-              <span class="icon-lock"
-                ><svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="52"
-                  height="64"
-                  viewBox="0 0 52 64"
-                  class="usa-banner__lock-image"
-                  role="img"
-                  aria-labelledby="banner-lock-title-default banner-lock-description-default"
-                  focusable="false"
-                >
-                  <title id="banner-lock-title-default">Lock</title>
-                  <desc id="banner-lock-description-default">A locked padlock</desc>
-                  <path
-                    fill="#000000"
-                    fill-rule="evenodd"
-                    d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
-                  /></svg
-              ></span>
-              ) or <strong>https://</strong> means you’ve safely connected to
-              the .gov website. Share sensitive information only on official,
-              secure websites.
+              <strong><%= t('shared.banner.secure_heading') %></strong>
+              <br> <%= t('shared.banner.secure_description_html', lock_icon: render('application/banner_lock_icon')) %>
             </p>
           </div>
         </div>

--- a/templates/config/locales/en.yml
+++ b/templates/config/locales/en.yml
@@ -1,0 +1,18 @@
+---
+en:
+  shared:
+    banner:
+      gov_description_html: A <strong>.gov</strong> website belongs to an official government organization in the United States.
+      gov_heading: Official websites use .gov
+      how: Here’s how you know
+      lock: Lock
+      locked_padlock: A locked padlock
+      official_site: An official website of the United States government
+      secure_description_html: A <strong>lock</strong> (%{lock_icon}) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+      secure_heading: Secure .gov websites use HTTPS
+      us_flag: U.S. Flag
+    languages:
+      en: English
+      es: Español
+      zh: 中文
+    skip_link: Skip to main content

--- a/templates/config/locales/es.yml
+++ b/templates/config/locales/es.yml
@@ -1,0 +1,14 @@
+---
+es:
+  shared:
+    banner:
+      gov_description_html: Un sitio web <strong>.gov</strong> pertenece a una organización oficial del Gobierno de Estados Unidos.
+      gov_heading: Los sitios web oficiales usan .gov
+      how: Así es como usted puede verificarlo
+      lock: Candado
+      locked_padlock: Candado cerrado
+      official_site: Un sitio oficial del Gobierno de Estados Unidos
+      secure_description_html: Un <strong>candado</strong> (%{lock_icon}) o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros.
+      secure_heading: Los sitios web seguros .gov usan HTTPS
+      us_flag: Bandera de Estados Unidos
+    skip_link: Salte al contenido principal

--- a/templates/config/locales/zh.yml
+++ b/templates/config/locales/zh.yml
@@ -1,0 +1,14 @@
+---
+zh:
+  shared:
+    banner:
+      gov_description_html: "<strong>“.gov”</strong>网站为美国官方政府组织机构网站。"
+      gov_heading: 官方网站使用“.gov”
+      how: 这里是了解途径
+      lock: 锁
+      locked_padlock: 上锁的挂锁
+      official_site: 美国政府的官方网站
+      secure_description_html: "<strong>锁形图标</strong> (%{lock_icon}) 或 <strong>“https://”</strong>表示您已安全连接到.gov网站。仅在安全的官方网站上分享敏感信息。"
+      secure_heading: 安全的.gov网站使用HTTPS
+      us_flag: 美国国旗
+    skip_link: 跳转到主要内容


### PR DESCRIPTION
Asks devs whether they want to add Spanish and Simplified Chinese language support as part of `rails new`. If they answer yes to either:
1. Adds appropriate locale yml file to application with translated strings for USWDS banner
2. Adds locale to supported locales for i18n
3. Adds locale-scoped routes to `config/routes.rb`

Regardless, creates an `en.yml` and updates banner to update strings in that file.

I decided against adding i18n-js for now since I wasn't sure how it jived with the two different JS approaches in the application (hotwire and non-hotwire).

From https://github.com/usagov/test-at-home/issues/306
Closes #9 

- [x] Add locales files for en, es, zh with banner text
- [x] Update banner in repo to use locale files
- [x] Maybe: Include I18n config with default locales
- [x] Maybe: include i18n-tasks
- [x] Maybe: include routes
- [-] ~Maybe: include i18n-js and related things~