### PR TITLE
Add circleci as a possible CI/CD pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,6 @@ ActionCable is included to enable the [Turbo Streams](https://turbo.hotwired.dev
 1. Optionally run the `rake db:create` and `rake db:migrate` setup steps
 1. Optionally create `manifest.yml` and variable files for cloud.gov deployment
 1. Optionally create Github Actions workflows
+1. Optionally create CircleCI workflows
 1. Optionally create [Architecture Decision Records](https://adr.github.io/) for above setup
 1. Commit the resulting project with git (unless `--skip-git` is passed)

--- a/template.rb
+++ b/template.rb
@@ -18,8 +18,12 @@ end
 
 @cloudgov_deploy = yes?("Create cloud.gov deployment files? (y/n)")
 @github_actions = yes?("Create Github Actions? (y/n)")
+@circleci_pipeline = yes?("Create CircleCI config? (y/n)")
 @adrs = yes?("Create initial Architecture Decision Records? (y/n)")
 @node_version = ask("What version of NodeJS are you using? (Blank to skip creating .nvmrc)")
+
+# copied from Rails' .ruby-version template implementation
+@ruby_version = ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}"
 
 if @node_version.present?
   # setup nvmrc
@@ -222,6 +226,14 @@ end
 
 if @github_actions
   directory "github", ".github"
+end
+
+if @circleci_pipeline
+  directory "circleci", ".circleci"
+  copy_file "docker-compose.ci.yml"
+  template "Dockerfile"
+else
+  remove_file "bin/ci-server-start"
 end
 
 if @adrs

--- a/templates/Dockerfile.tt
+++ b/templates/Dockerfile.tt
@@ -1,0 +1,13 @@
+FROM cimg/ruby:<%= @ruby_version %>-node
+
+ENV PORT=3000
+EXPOSE $PORT
+
+COPY --chown=circleci . /home/circleci/project
+RUN bundle install --deployment
+RUN yarn install --frozen-lockfile
+
+ENV RAILS_ENV=ci
+RUN bundle exec rake assets:precompile
+
+CMD ["./bin/ci-server-start"]

--- a/templates/README.md.tt
+++ b/templates/README.md.tt
@@ -10,7 +10,7 @@ guide for an introduction to the framework.
 
 ### Local Setup
 
-* Install Ruby <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+* Install Ruby <%= @ruby_version %>
 * Install NodeJS <%= @node_version %>
 * Install PostgreSQL: `brew install postgresql`
   * Add postgres to your PATH if it wasn't done automatically
@@ -74,7 +74,13 @@ Run everything: `bundle exec rake`
 GitHub actions are used to run all tests and scans as part of pull requests.
 
 Security scans are also run on a scheduled basis. Weekly for static code scans, and daily for dependency scans.
-<% else %>
+<% end %>
+<% if @circleci_pipeline %>
+CircleCI is used to run all tests and scans as part of pull requests.
+
+Security scans are also run on a daily schedule.
+<% end %>
+<% if !@github_actions && !@circleci_pipeline %>
 TBD
 <% end %>
 
@@ -111,7 +117,12 @@ Otherwise, they are set as a `((variable))` within `manifest.yml` and the variab
 1. Store variables that must be secret using [GitHub Environment Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-environment)
 1. Add the secret to the `env:` block of the deploy action [as in this example](https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/blob/a9e8d22aae2023a0afb631a6182251c04f597f7e/.github/workflows/deploy-stage.yml#L20)
 1. Add the appropriate `--var` addition to the `push_arguments` line on the deploy action [as in this example](https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/blob/a9e8d22aae2023a0afb631a6182251c04f597f7e/.github/workflows/deploy-stage.yml#L27)
-<% else %>
+<% end %>
+<% if @circleci_pipeline %>
+1. Store variables that must be secret using [CircleCI Environment Variables](https://circleci.com/docs/2.0/env-vars/)
+1. Add the appropriate `--var` addition to the `cf push` line on the deploy job
+<% end %>
+<% if !@github_actions && !@circleci_pipeline %>
 TBD
 <% end %>
 

--- a/templates/bin/ci-server-start
+++ b/templates/bin/ci-server-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# this script is used by docker-compose and Dockerfile to start up a servrer
+# for running OWASP in CircleCI
+
+dockerize -wait tcp://db:5432 -timeout 1m
+bundle exec rails db:schema:load --trace
+bundle exec rails server -b 0.0.0.0

--- a/templates/circleci/config.yml.tt
+++ b/templates/circleci/config.yml.tt
@@ -1,0 +1,274 @@
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@1.3.0
+  node: circleci/node@5.0.0
+  browser-tools: circleci/browser-tools@1.2.3
+
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:<%= @ruby_version %>-node
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          cache-only-lockfile: false
+          pkg-manager: yarn
+
+  test:
+    parallelism: 3
+    docker:
+      - image: cimg/ruby:<%= @ruby_version %>-node
+      - image: cimg/postgres:12.9
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: <%= app_name %>_test
+          POSTGRES_PASSWORD: ""
+    environment:
+      BUNDLE_JOBS: "3"
+      BUNDLE_RETRY: "3"
+      PGHOST: 127.0.0.1
+      PGUSER: circleci
+      PGPASSWORD: ""
+      RAILS_ENV: test
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          cache-only-lockfile: false
+          pkg-manager: yarn
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: Database setup
+          command: bundle exec rails db:schema:load --trace
+
+      # Precompile assets
+      # Load assets from cache if possible, precompile assets then save cache
+      # Multiple caches are used to increase the chance of a cache hit
+      # https://circleci.com/docs/2.0/caching/#full-example-of-saving-and-restoring-cache
+      - restore_cache:
+          keys:
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}
+
+      - run: bundle exec rake assets:precompile
+
+      - save_cache:
+          key: asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - public/assets
+            - tmp/cache/assets/sprockets
+
+      - ruby/rspec-test
+
+  static_security_scans:
+    docker:
+      - image: cimg/ruby:<%= @ruby_version %>-node
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          cache-only-lockfile: false
+          pkg-manager: yarn
+      - run:
+          name: Run Brakeman scan
+          command: bundle exec brakeman
+      - run:
+          name: Bundle audit
+          command: bundle exec rake bundler:audit
+      - run:
+          name: Yarn audit
+          command: bundle exec rake yarn:audit
+
+  owasp_scan:
+    machine:
+      image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+
+      # attempt to restore cache from build step to speed up local server startup time
+      # This will need to be updated if the cache key for the `install-(deps|packages)` steps changes
+      - restore_cache:
+          keys:
+            - gems-v1-{{ checksum "Gemfile.lock"  }}-{{ .Branch }}
+      - restore_cache:
+          keys:
+            - node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+
+      - run:
+          name: Start up local server
+          command: docker-compose -f docker-compose.ci.yml up -d
+      - run:
+          name: Create reports directory
+          command: mkdir reports
+      - run:
+          name: Run OWASP Zap
+          command: |
+            docker run -v $(pwd)/zap.conf:/zap/wrk/zap.conf:ro -v $(pwd)/reports:/zap/wrk:rw --rm \
+              --user zap:$(id -g) --network="project_ci_network" -t owasp/zap2docker-weekly \
+              zap-baseline.py -t http://web:3000 -c zap.conf -I -i -r owasp_report.html
+      - store_artifacts:
+          path: reports/owasp_report.html
+
+  a11y_scan:
+    docker:
+      - image: cimg/ruby:<%= @ruby_version %>-node
+      - image: cimg/postgres:12.9
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: <%= app_name %>_development
+          POSTGRES_PASSWORD: ""
+    environment:
+      BUNDLE_JOBS: "3"
+      BUNDLE_RETRY: "3"
+      PGHOST: 127.0.0.1
+      PGUSER: circleci
+      PGPASSWORD: ""
+      RAILS_ENV: ci
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          cache-only-lockfile: false
+          pkg-manager: yarn
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: Database setup
+          command: bundle exec rails db:schema:load --trace
+
+      # Precompile assets
+      # Load assets from cache if possible, precompile assets then save cache
+      # Multiple caches are used to increase the chance of a cache hit
+      # https://circleci.com/docs/2.0/caching/#full-example-of-saving-and-restoring-cache
+      - restore_cache:
+          keys:
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}
+            - asset-cache-v1-{{ .Environment.RAILS_ENV }}
+
+      - run: bundle exec rake assets:precompile
+
+      - save_cache:
+          key: asset-cache-v1-{{ .Environment.RAILS_ENV }}-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - public/assets
+            - tmp/cache/assets/sprockets
+
+      - run:
+          name: Start server
+          command: ./bin/rails server -p 3000
+          background: true
+
+      - run:
+          name: Wait for server
+          command: dockerize -wait http://localhost:3000 -timeout 1m
+
+      - run:
+          name: Run pa11y-ci
+          command: yarn run pa11y-ci
+
+  deploy:
+    docker:
+      - image: cimg/ruby:<%= @ruby_version %>-node
+    steps:
+      - checkout
+      - when:
+          condition:
+            or:
+              - equal: [<< pipeline.git.branch >>, "main"]
+              - equal: [<< pipeline.git.branch >>, "production"]
+          steps:
+            - ruby/install-deps
+            - run:
+                name: Vendor gems
+                command: bundle cache --all
+            - node/install-packages:
+                cache-only-lockfile: false
+                pkg-manager: yarn
+            - run:
+                name: Install Cloud Foundry CLI
+                command: |
+                  curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v7&source=github'
+                  sudo dpkg -i cf-cli_amd64.deb
+      - when:
+          condition:
+            and:
+              - equal:
+                  [
+                    << pipeline.project.git_url >>,
+                    "TKTK insert repo URL",
+                  ]
+              - equal: [<< pipeline.git.branch >>, "main"]
+          steps:
+            - run:
+                name: Deploy to staging
+                command: |
+                  cf push --strategy rolling --no-wait --vars-file config/deployment/stage.yml \
+                    --var rails_master_key=$RAILS_MASTER_KEY
+      - when:
+          condition:
+            and:
+              - equal:
+                  [
+                    << pipeline.project.git_url >>,
+                    "TKTK insert repo URL",
+                  ]
+              - equal: [<< pipeline.git.branch >>, "production"]
+          steps:
+            - run:
+                name: Deploy to prod
+                command: |
+                  cf push --strategy rolling --no-wait --vars-file config/deployment/prod.yml \
+                    --var rails_master_key=$RAILS_MASTER_KEY
+
+workflows:
+  version: 2.1
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - static_security_scans:
+          requires:
+            - build
+      - owasp_scan:
+          requires:
+            - build
+      - a11y_scan:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - test
+            - static_security_scans
+            - owasp_scan
+            - a11y_scan
+  daily_scan:
+    triggers:
+      - schedule:
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - dev
+                - main
+                - production
+    jobs:
+      - build
+      - static_security_scans:
+          requires:
+            - build
+      - owasp_scan:
+          requires:
+            - build

--- a/templates/docker-compose.ci.yml
+++ b/templates/docker-compose.ci.yml
@@ -1,0 +1,26 @@
+version: "3.2"
+services:
+  web:
+    build:
+      context: .
+    user: ${CURRENT_USER:-root}
+    networks:
+      - ci_network
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      RAILS_ENV: ci
+      DATABASE_URL: postgres://circleci:notasecret@db:5432/ci_db
+      RAILS_MASTER_KEY: $RAILS_MASTER_KEY
+  db:
+    image: cimg/postgres:12.9
+    environment:
+      POSTGRES_USER: circleci
+      POSTGRES_DB: ci_db
+      POSTGRES_PASSWORD: notasecret
+    networks:
+      - ci_network
+networks:
+  ci_network:


### PR DESCRIPTION
Changes, if circleci is chosen:

* adds the circleci config
* adds supporting docker files and `bin` script for running the OWASP scan


The code allows creating both github actions and circleci, for maximum chaos. Should we force one or the other?