### PR TITLE
Add gem-script to run rails new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - i18n generator
+- helper script to run rails new without cloning repo
 
 ## [0.2.0] - 2022-02-16
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rails_template_18f (0.2.0)
       activesupport (~> 7.0.0)
       railties (~> 7.0.0)
+      thor (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -7,35 +7,32 @@ See the `rails-6` branch for Rails 6.1.x
 
 ## Use for new Rails Project
 
-1. Clone this repository to your computer
-1. Change directory into the clone
-1. Run `rails new <<PATH_TO_PROJECT>> --rc=<<RC_FILE>>` with the appropriate rc file for your needs. The path should not be a subdirectory of this repository.
+1. `gem install rails_template_18f`
+1. `rails_template_18f help new` for usage instructions
 
-### Choosing which RC file to use
-
-You should run this template with either `railsrc` or `railsrc-hotwire` depending on your development needs.
+### Choosing whether to use `--hotwire`
 
 #### Server Rendered _or_ Single Page Applications
 
-`rails new <<PATH_TO_PROJECT>> --rc=railsrc`
+`rails_template_18f new <<PATH_TO_PROJECT>>` _or_ `rails_template_18f new <<PATH_TO_PROJECT>> --no-hotwire`
 
-The base `railsrc` file creates a Rails application that is appropriate for both server-rendered applications,
+This creates a Rails application that is appropriate for both server-rendered applications,
 as well as a basis for installing a separate Single Page Application (SPA) library such as React.
 
 #### A bit more JavaScript needed
 
-`rails new <<PATH_TO_PROJECT>> --rc=railsrc-hotwire`
+`rails_template_18f new <<PATH_TO_PROJECT>> --hotwire`
 
-The `railsrc-hotwire` file creates a Rails application that includes the [Hotwire](https://hotwired.dev/) JavaScript framework.
+This creates a Rails application that includes the [Hotwire](https://hotwired.dev/) JavaScript framework.
 
 Hotwire can be used to add [a bit of JavaScript](https://engineering.18f.gov/web-architecture/#:~:text=are%20more%20complex-,If%20your%20use%20case%20requires%20a%20bit%20of%20client%2Dside%20interactivity%2C%20use%20the%20above%20options%20with%20a%20bit%20of%20JavaScript.,-You%20might%20use)
 for more interactivity than server-rendered apps, but less than a full SPA.
 
 ### Available Options
 
-The following options can be added after `--rc=<<RC_FILE>>` to change how the template behaves.
+The following options can be added to change how the template behaves.
 
-**Important:** You must not pass `--skip-bundle` or `--skip-javascript` to `rails new` or various aspects of the template will be broken
+**Important:** You must not pass `--skip-bundle` or `--skip-javascript` to `rails_template_18f` or various aspects of the template will be broken
 
 #### `--javascript=esbuild`
 
@@ -46,7 +43,7 @@ maintaining IE11 support with esbuild may be tricky.
 
 Each of the skipped frameworks in `railsrc` can be overridden on the command line. For example: `--no-skip-active-storage` will include support for `ActiveStorage` document uploads
 
-### What `railsrc` does
+### What default use or `--no-hotwire` does
 
 ```
 --skip-active-storage   # don't include ActiveStorage for document upload
@@ -61,9 +58,9 @@ Each of the skipped frameworks in `railsrc` can be overridden on the command lin
 --database=postgresql   # default to PostgreSQL
 ```
 
-### What `railsrc-hotwire` does
+### What `--hotwire` does
 
-`railsrc-hotwire` is identical to `railsrc` except that [Hotwire](https://hotwired.dev/) and [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html) are not skipped.
+Identical to `--no-hotwire` except that [Hotwire](https://hotwired.dev/) and [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html) are not skipped.
 
 ActionCable is included to enable the [Turbo Streams](https://turbo.hotwired.dev/handbook/streams) functionality of Hotwire.
 

--- a/exe/rails_template_18f
+++ b/exe/rails_template_18f
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$gem_path = File.expand_path('..', __dir__)
-
 require "thor"
 
 class CLI < Thor
@@ -22,8 +20,9 @@ class CLI < Thor
     all other arguments will be passed as-is to `rails new`
   LONGDESC
   def new(app_directory, *rails_arguments)
+    gem_path = File.expand_path("..", __dir__)
     railsrc = options[:hotwire] ? "railsrc-hotwire" : "railsrc"
-    run "rails new #{app_directory} --rc=#{File.join($gem_path, railsrc)} #{rails_arguments.join(" ")}"
+    run "rails new #{app_directory} --rc=#{File.join(gem_path, railsrc)} --template=#{File.join(gem_path, "template.rb")} #{rails_arguments.join(" ")}"
   end
 end
 

--- a/exe/rails_template_18f
+++ b/exe/rails_template_18f
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$gem_path = File.expand_path('..', __dir__)
+
+require "thor"
+
+class CLI < Thor
+  include Thor::Actions
+
+  desc "new APP_DIRECTORY [options] [rails new arguments]", "Run rails new with 18F flavor"
+  option :hotwire, type: :boolean, default: false, desc: "Enable hotwire JS framework"
+  long_desc <<-LONGDESC
+    Create a new rails application in <APP_DIRECTORY> as customized by
+
+    * railsrc: https://github.com/18F/rails-template/blob/main/railsrc
+
+    * template.rb: https://github.com/18F/rails-template/blob/main/template.rb
+
+    with --hotwire option, includes the Hotwire JS framework
+
+    all other arguments will be passed as-is to `rails new`
+  LONGDESC
+  def new(app_directory, *rails_arguments)
+    railsrc = options[:hotwire] ? "railsrc-hotwire" : "railsrc"
+    run "rails new #{app_directory} --rc=#{File.join($gem_path, railsrc)} #{rails_arguments.join(" ")}"
+  end
+end
+
+CLI.start(ARGV)

--- a/rails-template-18f.gemspec
+++ b/rails-template-18f.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.add_dependency "railties", "~> 7.0.0"
   spec.add_dependency "activesupport", "~> 7.0.0"
+  spec.add_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "rspec", "~> 3.11"
   spec.add_development_dependency "ammeter", "~> 1.1"


### PR DESCRIPTION
Avoids the step of having to clone the repo first.

closes #34 